### PR TITLE
Use self-built material-ui to make date-picker buttons clickable on mobile devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "fluxible-router": "^0.1.7",
     "isomorphic-fetch": "^2.0.2",
     "jade": "^1.10.0",
-    "material-ui": "^0.10.2",
+    "material-ui": "MrOrz/material-ui#update-datepicker",
     "morgan": "^1.5.3",
     "newrelic": "^1.19.2",
     "object-assign": "^2.0.0",


### PR DESCRIPTION
Fixes #31 for now.
