### PR TITLE
callback immediately to preserve server rendering content

### DIFF
--- a/common/decorators/createEnterTransitionHook.js
+++ b/common/decorators/createEnterTransitionHook.js
@@ -15,8 +15,12 @@ export default function createEnterTransitionHook(
     static onEnterCreator = (store) => {
       const hook = transitionHookCreator(store);
       return (state, transition, callback) => {
-        const promise = hook(state, transition) || Promise.resolve(true);
-        promise.then(() => callback(), callback);
+        const promise = hook(state, transition);
+        if (promise && promise.then) {
+          promise.then(() => callback(), callback);
+        } else {
+          callback();
+        }
       };
     }
 


### PR DESCRIPTION
according to https://github.com/tomchentw/redux-universal/commit/16a956078f6ac8b14b1023ba0ad43cdad857ed1e
which will cause something like if we return `undefined` to `createEnter... callback` 

```
Warning: React attempted to reuse markup in a container but the checksum was invalid. 
This generally means that you are using server rendering and
the markup generated on the server was not what the client was expecting. 
React injected new markup to compensate which works but 
you have lost many of the benefits of server rendering. Instead, 
figure out why the markup being generated is different on the client or server:
 (client) <noscript data-reacti
 (server) <div class="app" data
```

though we didn't face that problem yet, but fix this to prevent future bugs from biting us.
